### PR TITLE
Upgrade dart_sass to 1.49.11

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ config :esbuild,
   ]
 
 config :dart_sass,
-  version: "1.39.0",
+  version: "1.49.11",
   default: [
     args: ~w(css/app.scss ../priv/static/assets/app.css),
     cd: Path.expand("../assets", __DIR__)


### PR DESCRIPTION
This is the minimum version which supports arm64, allowing the example app to be run on Apple Silicon.
https://github.com/sass/dart-sass/releases/tag/1.49.11