### PR TITLE
Upgrade `:dart_sass` to be runnable on linux.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ config :esbuild,
   ]
 
 config :dart_sass,
-  version: "1.49.11",
+  version: "1.61.0",
   default: [
     args: ~w(css/app.scss ../priv/static/assets/app.css),
     cd: Path.expand("../assets", __DIR__)


### PR DESCRIPTION
I'd been seeing a bunch of errors running a local copy on linux:

```bash
** (RuntimeError) Installing dart_sass on Linux platforms requires version >= 1.58.0, got: "1.49.11"
    (dart_sass 0.7.0) lib/dart_sass.ex:218: DartSass.install/0
    (dart_sass 0.7.0) lib/dart_sass.ex:204: DartSass.install_and_run/2
    (phoenix 1.7.10) lib/phoenix/endpoint/watcher.ex:19: Phoenix.Endpoint.Watcher.watch/2
    (elixir 1.15.7) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: &Phoenix.Endpoint.Watcher.watch/2
    Args: ["sass", {DartSass, :install_and_run, [:default, ["--embed-source-map", "--source-map-urls=absolute", "--watch"]]}]
```

![Screenshot from 2023-11-16 10-07-11](https://github.com/elixir-desktop/desktop-example-app/assets/30454698/2869fd1f-5f4b-45f6-9371-0b1752ac7190)
