### PR TITLE
Upgrade github actions API

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -157,7 +157,7 @@ jobs:
         mix desktop.installer
 
     - name: Archive Installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Windows-Installer
         path: |
@@ -228,7 +228,7 @@ jobs:
         mix desktop.installer
 
     - name: Archive MacOS Installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: MacOS-Installer
         path: |
@@ -266,7 +266,7 @@ jobs:
         chmod +x $NAME
 
     - name: Archive Installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Linux-Installer
         path: |


### PR DESCRIPTION
github actions API versions 1 and 2 are now deprecated.  It doesn't seem that any of the upstream changes affect the script: there was no assumption of mutable artifacts or hidden files.