### PR TITLE
Pin exqlite to avoid a version incompatiblity

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,9 @@ defmodule Todo.MixProject do
       # Phoenix
       {:phoenix, "~> 1.8"},
       {:phoenix_ecto, "~> 4.5"},
-      {:ecto_sqlite3, "~> 0.22"},
+      {:ecto_sqlite3, "~> 0.22.0"},
+      # Temporarily pin sqlite3 adapter to avoid incompatibilities.
+      {:exqlite, "~> 0.22.0"},
       {:phoenix_html, "~> 4.1"},
       {:phoenix_live_dashboard, "~> 0.8.3"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},


### PR DESCRIPTION
Without this, I was seeing mix fetch exqlite v0.33.0, which seems to cause issues like the following:

> The on_load function for module Elixir.Exqlite.Sqlite3NIF returned: {:error, {:bad_lib, ~c"Function not found 'Elixir.Exqlite.Sqlite3NIF':bind/3"}}

Pinning the version to the explicit exqlite dependency used by ecto_sqlite3 seems to solve the issue temporarily.  A better fix would be for ecto_sqlite3 to more carefully pin its own dependency, at which point the line here can be removed or simplified.

It's reasonable to pin these dependencies using the third level of version numbering, because they both follow the unofficial "pre-1.0" style of semantic versioning where the second and not the first term serves as the major (breaking) version.